### PR TITLE
Nested rendered components limitations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 gem "view_component", require: "view_component/engine"
-gem "lookbook"
+gem "lookbook", ">= 0.5.0.beta.2"
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (0.4.8)
+    lookbook (0.5.0.beta.2)
       htmlbeautifier (~> 1.3)
       listen (~> 3.0)
       rails (>= 5.0)
@@ -160,7 +160,7 @@ GEM
     redcarpet (3.5.1)
     regexp_parser (2.2.0)
     rexml (3.2.5)
-    rouge (3.26.1)
+    rouge (3.27.0)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -217,7 +217,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   jbuilder (~> 2.7)
   listen (~> 3.3)
-  lookbook
+  lookbook (>= 0.5.0.beta.2)
   pg
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/components/elements/button_component.html.erb
+++ b/app/components/elements/button_component.html.erb
@@ -3,4 +3,7 @@
   <% if @arrow %>
     <span class="ml-2">&rarr;</span>
   <% end %>
+  <% if @icon %>
+      <span class="ml-2">👀</span>
+  <% end %>
 </button>

--- a/app/components/elements/button_component.rb
+++ b/app/components/elements/button_component.rb
@@ -1,7 +1,8 @@
 class Elements::ButtonComponent < ViewComponent::Base
-  def initialize(theme: :default, arrow: false)
+  def initialize(theme: :default, arrow: false, icon: false)
     @theme = theme
     @arrow = arrow
+    @icon = icon
   end
 
   def theme_classes

--- a/app/components/elements/card_component.html.erb
+++ b/app/components/elements/card_component.html.erb
@@ -1,0 +1,13 @@
+<%= tag.div class: classes, data: data do %>
+  <% if rows.any? %>
+    <%= tag.div class: rows_classes do %>
+      <% rows.each do |row| %>
+        <%= tag.div class: row.classes, data: row.data do %>
+          <%= row %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= content %>
+  <% end %>
+<% end %>

--- a/app/components/elements/card_component.rb
+++ b/app/components/elements/card_component.rb
@@ -1,0 +1,35 @@
+class Elements::CardComponent < ViewComponent::Base
+  renders_many :rows, "Elements::CardRowComponent"
+  attr_reader :size, :data
+
+  def initialize(size: "medium", data: nil)
+    @size = size
+  end
+
+  def rows_classes
+    classes = ["card-rows"]
+    classes << "card-rows--#{size}"
+    classes
+  end
+
+  def classes
+    classes = ["bg-yellow-50 p-8 rounded-lg"]
+    classes
+  end
+  class Elements::CardRowComponent < ViewComponent::Base
+    attr_reader :data
+
+    def initialize(data: nil)
+      @data = data
+    end
+
+    def classes
+      classes = ["card-row"]
+      classes
+    end
+
+    def call
+      content
+    end
+  end
+end

--- a/app/views/layouts/preview.html.erb
+++ b/app/views/layouts/preview.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html style="background-color: <%= params[:lookbook][:display][:bg_color] %>">
 <head>
   <title>Component Preview</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,11 @@ module LookbookDemo
     config.view_component.default_preview_layout = "preview"
     config.view_component.preview_controller = "PreviewController"
 
+    config.lookbook.preview_display_params = {
+      bg_color: "#fff",
+      max_width: "100%"
+    }
+
     config.lookbook.experimental_features = true # Opt in to ALL experimental features. Not recommended!
   end
 end

--- a/test/components/previews/elements/avatar_component_preview.rb
+++ b/test/components/previews/elements/avatar_component_preview.rb
@@ -1,6 +1,7 @@
 class Elements::AvatarComponentPreview < ViewComponent::Preview
   # @label Rounded
   #
+  # @display bg_color #f00
   # @param size [Symbol] select [[Small, sm], [Medium, md], [Large, lg]]]
   def default(size: :md)
     render Elements::AvatarComponent.new(src: "https://placekitten.com/300/300", size: size)
@@ -8,6 +9,7 @@ class Elements::AvatarComponentPreview < ViewComponent::Preview
 
   # @label Square
   #
+  # @display bg_color "#f00"
   # @param (see #default)
   def format_square(size: :md)
     render Elements::AvatarComponent.new(src: "https://placekitten.com/300/300", size: size, square: true)

--- a/test/components/previews/elements/button_component_preview.rb
+++ b/test/components/previews/elements/button_component_preview.rb
@@ -7,8 +7,9 @@ class Elements::ButtonComponentPreview < ViewComponent::Preview
   # @param text
   # @param theme [Symbol] select [primary, secondary, danger]
   # @param arrow
-  def playground(text: "Click me", theme: :danger, arrow: false)
-    render Elements::ButtonComponent.new(theme: theme, arrow: arrow) do
+  # @param icon
+  def playground(text: "Click me", theme: :danger, arrow: false, icon: false)
+    render Elements::ButtonComponent.new(theme: theme, arrow: arrow, icon: icon) do
       text
     end
   end

--- a/test/components/previews/elements/card_component_preview.rb
+++ b/test/components/previews/elements/card_component_preview.rb
@@ -1,0 +1,18 @@
+class Elements::CardComponentPreview < ViewComponent::Preview
+  # @display bg_color "#409bf5"
+  def default
+    render(Elements::CardComponent.new) do
+      "Card as content container"
+    end
+  end
+
+  # @display bg_color "#409bf5"
+  # @param size [Symbol] select [medium, large]
+  def with_spacing(size: :medium)
+    render(Elements::CardComponent.new(size: size)) do |c|
+      c.row { "Row" }
+      c.row { "Row" }
+      c.row { "Row" }
+    end
+  end
+end

--- a/test/components/previews/elements/card_component_preview.rb
+++ b/test/components/previews/elements/card_component_preview.rb
@@ -15,4 +15,19 @@ class Elements::CardComponentPreview < ViewComponent::Preview
       c.row { "Row" }
     end
   end
+
+  # @display bg_color "#409bf5"
+  # @display max_width 800px
+  def multiple_renders_failing
+    render(Elements::CardComponent.new) { "Card #1" }
+    render(Elements::CardComponent.new) { "Card #2" }
+    render(Elements::CardComponent.new) { "Card #3" }
+  end
+
+  ### ## Question:
+  ### Is it possible to pass `params` to the erb file?
+  # @display bg_color "#409bf5"
+  # @display max_width 800px
+  def multiple_renders_working
+  end
 end

--- a/test/components/previews/elements/card_component_preview/multiple_renders_working.html.erb
+++ b/test/components/previews/elements/card_component_preview/multiple_renders_working.html.erb
@@ -1,0 +1,5 @@
+<%= render(Elements::CardComponent.new) do |c| %> Card #1 <% end %>
+<br>
+<%= render(Elements::CardComponent.new) do |c| %> Card #2 <% end %>
+<br>
+<%= render(Elements::CardComponent.new) do |c| %> Card #3 <% end %>


### PR DESCRIPTION
What I'm aiming to do is recreate something similar to GitHub's DS ([_Primer_](https://primer.style/view-components)) examples, whereby multiple components can be rendered in order to demonstrate their composability (see [Justify Centre](https://primer.style/view-components/components/flex#justify-center)).

- Using plain ruby (and TagHelper), only the last ViewComponent is rendered (see [Multiple Renders Failing](http://127.0.0.1:3000/lookbook/elements/card/multiple_renders_failing)).
- I noticed [BAOAgency](https://github.com/baoagency/polaris_view_components) are using ruby files and functions to source `erb`, which is a really nice solution (see [Multiple Renders Working](http://127.0.0.1:3000/lookbook/elements/card/multiple_renders_working)) since the source is now `erb` and more representative of how developers will interact with the ViewComponents, however this means we lose support for `params`.

Is there a way to create `erb` examples that support `params`?

**Note**: Just the last commit, [`3f1785`](https://github.com/allmarkedup/lookbook-demo/pull/3/commits/3f1785dbae037871fd8249b830ef3d8d830b8877), is important here.