### PR TITLE
Websocket fails to connect when Lookbook is mounted at root

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 gem "view_component"
-gem "lookbook"
+gem "lookbook", "0.6.1"
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,10 +95,11 @@ GEM
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (0.5.0)
+    lookbook (0.6.1)
+      actioncable
       htmlbeautifier (~> 1.3)
       listen (~> 3.0)
-      rails (>= 5.0)
+      railties (>= 5.0)
       redcarpet (~> 3.5)
       rouge (~> 3.26)
       view_component (~> 2.0)
@@ -161,7 +162,7 @@ GEM
     redcarpet (3.5.1)
     regexp_parser (2.2.0)
     rexml (3.2.5)
-    rouge (3.27.0)
+    rouge (3.28.0)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -218,7 +219,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   jbuilder (~> 2.7)
   listen (~> 3.3)
-  lookbook
+  lookbook (= 0.6.1)
   pg
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/components/elements/list_component.rb
+++ b/app/components/elements/list_component.rb
@@ -1,0 +1,15 @@
+class Elements::ListComponent < ViewComponent::Base
+  renders_many :items, "ItemComponent"
+
+  def call
+    tag.ol do
+      safe_join items
+    end
+  end
+
+  class ItemComponent < ViewComponent::Base
+    def call
+      tag.li content
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  root "demo#index"
-  mount Lookbook::Engine, at: "/lookbook"
+  # root "demo#index"
+  mount Lookbook::Engine, at: "/"
 end

--- a/test/components/previews/elements/list_component_preview.rb
+++ b/test/components/previews/elements/list_component_preview.rb
@@ -1,0 +1,13 @@
+# @label Simple list
+class Elements::ListComponentPreview < ViewComponent::Preview
+  # This example uses the `with_content` helper to set inline content.
+  #
+  # You can read more about it in the ViewComponent [slots documentation](https://viewcomponent.org/guide/slots.html#with_content).
+  def default
+    render Elements::ListComponent.new do |list|
+      list.item.with_content "One"
+      list.item.with_content "Two"
+      list.item.with_content "Three"
+    end
+  end
+end


### PR DESCRIPTION
Demoing websocket failing when the Lookbook engine is mounted at the root of the rails app, breaking the hot reloading:

**Console errors:**
`WebSocket connection to 'ws://cable/?uid=1646144935981' failed`

When Lookbook is mounted at `/lookbook`, the websocket is successful, and in the form:
`ws://lookbook/cable?uid=1646144935981`

Somehow the param isn't getting appended correctly, and breaks hot reloading.